### PR TITLE
Use fully-qualified collection names

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 - name: Create the /etc/sysctl.d directory (if necessary)
-  file:
+  ansible.builtin.file:
     path: /etc/sysctl.d
     state: directory
     mode: 0755
 
 - name: Copy sysctl file
-  copy:
+  ansible.builtin.copy:
     src: more_ephemeral_ports.conf
     dest: /etc/sysctl.d/99-more_ephemeral_ports.conf
     mode: 0644

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-# tasks file for more_ephemeral_ports
-
 - name: Create the /etc/sysctl.d directory (if necessary)
   file:
     path: /etc/sysctl.d

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 - name: Create the /etc/sysctl.d directory (if necessary)
   ansible.builtin.file:
+    mode: 0755
     path: /etc/sysctl.d
     state: directory
-    mode: 0755
 
 - name: Copy sysctl file
   ansible.builtin.copy:
-    src: more_ephemeral_ports.conf
     dest: /etc/sysctl.d/99-more_ephemeral_ports.conf
     mode: 0644
+    src: more_ephemeral_ports.conf


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates this role to use fully-qualified collection names for Ansible tasks and to ensure that all task arguments are sorted alphabetically.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

I am hunting down a deprecation warning while building fresh [CyHy AMIs](https://github.com/cisagov/cyhy_amis) and this is the first Ansible dependency I checked. While the warning was not found here I saw a couple out-of-date items and thought I would correct them while I'm here.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass successfully.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
